### PR TITLE
Fix fragment cleanup leak

### DIFF
--- a/src/jsx/Fragment.ts
+++ b/src/jsx/Fragment.ts
@@ -78,10 +78,9 @@ export default class Fragment<T = any> extends GObject.Object {
     }
 
     destroy() {
+        this.emit("destroy")
         for (const id of this.connectionIds.values()) {
             super.disconnect(id)
         }
-
-        this.emit("destroy")
     }
 }


### PR DESCRIPTION
Previously, upon destruction, fragments would emit the `destroy` signal only **after** disconnecting all signal handlers, meaning any `destroy` signal handler would never be called. In this example component:
```jsx
default function Test() {
    const state = new State([1]);

    return (
        <window visible application={App} cssClasses={["test-window"]}>
            <box>
                <box>
                    <With value={state()}>
                        {(v) =>
                            v.length > 0 ? (
                                <box>
                                    <With value={state()}>
                                        {(state) => (
                                            <label label={state.toString()} />
                                        )}
                                    </With>
                                </box>
                            ) : (
                                <label label="World" />
                            )
                        }
                    </With>
                </box>
                <button
                    $clicked={() => {
                        if (state.get().length > 0) {
                            state.set([]);
                        } else {
                            state.set([1]);
                        }
                    }}
                >
                    Click
                </button>
            </box>
        </window>
    );
}
```

When the button is clicked, the subscription to `state` is never cleaned up, leaving a dangling connection. The fix is to simply emit the `destroy` signal before disconnecting all signal handlers.