### PR TITLE
improve scope flexibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export { With } from "./jsx/With.js"
 export { This } from "./jsx/This.js"
 export {
     type Context,
-    type Scope,
+    Scope,
     createRoot,
     getScope,
     onCleanup,

--- a/src/jsx/state.ts
+++ b/src/jsx/state.ts
@@ -3,6 +3,7 @@ import Gio from "gi://Gio"
 import GLib from "gi://GLib"
 import { type Pascalify, camelify, kebabify } from "../util.js"
 import type { DeepInfer, RecursiveInfer } from "../variant.js"
+import { Scope } from "./scope.js"
 
 type SubscribeCallback = () => void
 type DisposeFunction = () => void
@@ -432,4 +433,9 @@ export function createSettings<const T extends Record<string, string>>(
             ],
         ]),
     )
+}
+
+export function createScope(parent?: Scope | null) {
+    const scope = new Scope(parent)
+    return [scope.run, scope.dispose]
 }


### PR DESCRIPTION
I want to solve the problem of increased list rendering memoisation scope. To do this, I propose 3 solutions (only 1 is required):

1. Extend `<For>`, allowing it to take additional props for external management, not exposing `Scope`. Downside is this complicates the API.
2. Softly expose `Scope` through `createScope`
3. Fully expose `Scope`