### PR TITLE
fix: snapshot subscriber callbacks before execution

### DIFF
--- a/src/jsx/state.ts
+++ b/src/jsx/state.ts
@@ -96,7 +96,8 @@ export function createState<T>(init: T): State<T> {
         const value: T = typeof newValue === "function" ? newValue(currentValue) : newValue
         if (currentValue !== value) {
             currentValue = value
-            subscribers.forEach((cb) => cb())
+            const currentSubscribers = Array.from(subscribers)
+            currentSubscribers.forEach((cb) => cb())
         }
     }
 


### PR DESCRIPTION
We don't snapshot the subscriber callbacks before executing them upon setting state, so the subscriber callbacks can modify and grow the callback array, leading to unpredictable behaviour and/or infinite loops. Here's an example:

```tsx
const [state, setState] = createState(1);

let dispose: () => void;
const onStateChange = () => {
  // handle state
  dispose();
  dispose = state.subscribe(onStateChange);
};
dispose = state.subscribe(onStateChange);
setState(2);
```

What's essentially happening under the hood is this:

```typescript
const set = new Set([1]);
  set.forEach((n) => {
    set.delete(n);
    set.add(n + 1);
  });
```

So we just snapshot the set before calling each callback.

This behaviour is more consistent and follows standard GTK signal connection behaviour